### PR TITLE
fix: order resumes by created_at so uploaded resumes appear

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1350,7 +1350,7 @@ async def get_resumes(user: dict = Depends(get_current_user)):
             return _supabase_client.table("user_resumes") \
                 .select("*") \
                 .eq("user_id", user["user_id"]) \
-                .order("uploaded_at", desc=True) \
+                .order("created_at", desc=True) \
                 .execute()
 
         response = await asyncio.to_thread(_fetch_resumes)

--- a/frontend/src/components/ResumeManager.tsx
+++ b/frontend/src/components/ResumeManager.tsx
@@ -31,7 +31,7 @@ interface Resume {
   id: string;
   filename: string;
   file_path: string;
-  uploaded_at: string;
+  created_at: string;
   analysis_status?: string;
 }
 
@@ -489,7 +489,7 @@ export function ResumeManager() {
                       >
                         {(() => {
                           try {
-                            return formatDistanceToNow(new Date(resume.uploaded_at), { addSuffix: true });
+                            return formatDistanceToNow(new Date(resume.created_at), { addSuffix: true });
                           } catch {
                             return "recently";
                           }


### PR DESCRIPTION
## Problem

Uploaded resumes never appeared under "Uploaded Resumes" in the UI, even though upload and AI analysis both completed successfully.

`GET /resumes` sorted by `uploaded_at` — a column that does not exist on `user_resumes`. The real column is `created_at`. Confirmed against the database:

```
ERROR: 42703: column "uploaded_at" does not exist
```

Every request to the endpoint raised that error, was swallowed by the broad `except Exception`, and returned a generic 500. `ResumeManager.fetchResumes` only populates state `if (response.ok)` with no `else` branch, so the list silently rendered empty. Two fully-analyzed resumes were sitting in the table the whole time.

## Fix

Align all three references on the actual column name:

- `backend/app/main.py:1353` — `order("uploaded_at")` → `order("created_at")`
- `frontend/src/components/ResumeManager.tsx:34` — `Resume.uploaded_at` → `created_at`
- `frontend/src/components/ResumeManager.tsx:492` — the timestamp read feeding `formatDistanceToNow`

The frontend needed changing too: it read `uploaded_at` off the response for the relative-time label, which would have rendered "recently" for every row even after the backend started returning data.

## Verification

- Ran the corrected query against the live database — returns both resume rows in the expected order.
- `backend/app/main.py` compiles.
- Confirmed zero remaining `uploaded_at` references repo-wide.
- Confirmed `interface Resume` is file-local (not exported) with a single read site, so the rename cannot affect other modules.
- Checked no other resume query references a bad column (`resume_analyzer.py:158` sorts on `created_at`, which exists).

**Not verified:** full-project `npx tsc --noEmit` ran past 15 minutes without completing and was killed, so this change has not been through a typechecker. The frontend rename was verified by grep and scope analysis instead. `next build` during the Docker deploy will typecheck it.

## Test plan

- [ ] Restart backend, load the resumes view, confirm both resumes render with correct relative timestamps and status badges
- [ ] Upload a new resume, confirm it appears immediately and transitions `processing` → `completed`

## Follow-ups not in this PR

- `ResumeManager.tsx:75` — missing `else` makes a failed fetch indistinguishable from "no resumes"
- `main.py:1358` — `except Exception` buried the real Postgres error behind a generic 500
- `backend/.env.example:17-19` — dead `REDIS_URL`; Redis was fully replaced by Supabase